### PR TITLE
Fix service subnet initial config

### DIFF
--- a/kubeadm-init.yaml.tpl
+++ b/kubeadm-init.yaml.tpl
@@ -3,6 +3,7 @@ kind: MasterConfiguration
 kubernetesVersion: v1.9.1
 networking:
   podSubnet: K8SHA_CIDR
+  serviceSubnet: K8SHA_SVC_CIDR
 apiServerCertSANs:
 - K8SHA_HOSTNAME1
 - K8SHA_HOSTNAME2


### PR DESCRIPTION
Had a try to your repo because is the most straight forward one I've found to follow how the K8S moving parts are related to each other in an HA configuration. Now seems even simple :-)

So, first of all, thank you, very good job!

After set the cluster up I just figured out the K8SHA_SVC_CIDR was configured with the default 10.96.0.0/12 instead the one I specified.

To fix it just added the corresponding line in the kubeadm-init according the documentation, but couldn't test it afterwards.

If I have spare time will try to add AWS support to the repo. Will update you.

