### PR TITLE
Update check_apiserver.sh

### DIFF
--- a/keepalived/check_apiserver.sh
+++ b/keepalived/check_apiserver.sh
@@ -4,7 +4,7 @@
 err=0
 for k in $(seq 1 12)
 do
-    check_code=$(curl -k https://localhost:6443)
+    check_code=$(curl -k https://localhost:16443)
     if [[ $check_code == "" ]]; then
         err=$(expr $err + 1)
         sleep 5


### PR DESCRIPTION
fix the bug: 
  - keepalived is using to keep the nginx ha function.Even the apiserver is down , the nginx still can work and the nginx will keep the apiserver ha.